### PR TITLE
Fix astore register model for performance charts, add python wrapper …

### DIFF
--- a/src/sasctl/tasks.py
+++ b/src/sasctl/tasks.py
@@ -247,6 +247,8 @@ def register_model(model, name, project, repository=None, input=None,
             files.append({'name': 'dmcas_epscorecode.sas',
                           'file': mas_module.score_code(dest='CAS'),
                           'role': 'score'})
+            files.append({'name': 'python_wrappercode.py',
+                          'file': mas_module.score_code(dest='PY')})
 
             model['inputVariables'] = [var.as_model_metadata()
                                        for var in mas_module.variables

--- a/src/sasctl/utils/astore.py
+++ b/src/sasctl/utils/astore.py
@@ -148,7 +148,12 @@ def create_files_from_astore(table):
         raise RuntimeError(result)
 
     astore_key = result.Key.Key[0].strip()
-    ep_ds2 = result.epcode
+
+    # Remove "Keep" sas code from CAS/EP code so full table plus output are returned
+    # This is so the MM performance charts and test work
+    keepstart=result.epcode.find("Keep")
+    keepend=result.epcode.find(";",keepstart)
+    ep_ds2 = result.epcode[0:keepstart] + result.epcode[keepend+1:]
     package_ds2 = _generate_package_code(result)
     model_properties = _get_model_properties(result)
     input_vars = [get_variable_properties(var)
@@ -163,7 +168,7 @@ def create_files_from_astore(table):
         table.save(name=astore_filename, caslib='ModelStore', replace=True)
 
     file_metadata = [{'role': 'analyticStore', 'name': ''},
-                     {'role': 'score', 'name': 'dmcas_packagescorecode.sas'}]
+                     {'role': 'score', 'name': 'dmcas_epscorecode.sas'}]
 
     astore_metadata = [{'name': astore_filename,
                         'caslib': 'ModelStore',

--- a/src/sasctl/utils/pymas/core.py
+++ b/src/sasctl/utils/pymas/core.py
@@ -332,6 +332,7 @@ class PyMAS:
         # Lines of Python code to be embedded in DS2
         python_source = list(self.wrapper)
 
+        self.python_source = python_source
         self.variables = variables
         self.return_code = return_code
         self.return_message = return_msg
@@ -357,6 +358,10 @@ class PyMAS:
         """
 
         dest = dest.upper()
+
+        # Python code return
+        if dest == 'PY':
+            return '\n'.join(map(str, self.python_source))
 
         # Check for names that could result in DS2 errors.
         DS2_KEYWORDS = ['input', 'output']


### PR DESCRIPTION
Fix two items:
1) SAS astore model registered for CAS have a "Keep" sas code addition that causes issues with MM performance, removed this from auto-generated code (or stop auto-generated code, you need to have input table) so the CAS/EP score code will output the inputs + outputs.  This si needed so MM performance metrics that test the model against new data works.  Also, properly marked the score code to cas/ep code because the MM Tester only uses that flag to determine which file to publish to CAS for testing score code.
2) python model register want to have the python wrapper code in a py file to extract for their own testing.  This creates that file for python models.

Note, these are just fixes to existing code so they work properly, not really new features.
