### PR TITLE
Update index.rst missing step

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -222,6 +222,7 @@ Execute a model in MAS
     from sasctl.services import microanalytic_score as mas
 
     module = mas.get_module('Module Name')
+    module = mas.define_steps(module)
     module.predict(model_inputs)
 
 


### PR DESCRIPTION
When you use mas.get_module() the module doesn't come with the steps methods defined. Not sure if it's a bug but the addition of mas.define_steps(module) is enough to fix it.