### PR TITLE
Fixed parent folder problem

### DIFF
--- a/src/sasctl/_services/folders.py
+++ b/src/sasctl/_services/folders.py
@@ -41,13 +41,17 @@ class Folders(Service):
         -------
 
         """
-        parent = cls.get_folder(parent)
+        if parent is not None:
+            parent = cls.get_folder(parent)
+
+            if parent is None:
+                raise ValueError('`parent` folder does not exist')
 
         body = {
             'name': name,
             'description': description,
             'folderType': 'folder',
-            'parentFolderUri': parent.id if parent else None,
+            'parentFolderUri': '/folders/folders/'+parent.id if parent else None,
         }
 
         return cls.post(


### PR DESCRIPTION

* The parent folder's URI must start with "/folders/folders/"
* If the parent folder does not exist, return an error instead of trying create in the root folder