### PR TITLE
Dev codecovflags

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -41,14 +41,13 @@ jobs:
 
       - name: Install dependencies (Common)
         run: |
-          # Setup tox
+          # Setup tox & Codecov uploader
           pip install --upgrade pip
-          pip install tox tox-gh-actions codecov
+          pip install tox tox-gh-actions pytest pytest-cov
 
       - name: Run Tests
         run: |
           tox
-          codecov
 
 
   gh-pages:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -67,14 +67,15 @@ jobs:
           flags: integration
           verbose: true
 
-      - name: Upload Scenario Test Coverage
-        uses: codecov/codecov-action@v3
-        with:
-          directory: ./.reports/
-          fail_ci_if_error: true
-          files: scenarios.xml
-          flags: scenarios
-          verbose: true
+# Uncomment when scenario test cases are working again
+#      - name: Upload Scenario Test Coverage
+#        uses: codecov/codecov-action@v3
+#        with:
+#          directory: ./.reports/
+#          fail_ci_if_error: true
+#          files: scenarios.xml
+#          flags: scenarios
+#          verbose: true
 
   gh-pages:
     name: "Build Documentation"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       LANG: en_US.UTF-8
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9] #, '3.10'] <-- auto fails due to lack of 3.9 & 3.10 env in tox.ini
+        python-version: [3.5, 3.6, 3.7, 3.8] #, 3.9, '3.10'] <-- auto fails due to lack of 3.9 & 3.10 env in tox.ini
         os-version: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -50,30 +50,33 @@ jobs:
           tox
 
       - name: Upload Unit Test Coverage
+        if: matrix.os-version == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           directory: ./.reports/
           fail_ci_if_error: true
-          files: unit.xml
+          file: unit.xml
           flags: unit
           verbose: true
 
       - name: Upload Integration Test Coverage
+        if: matrix.os-version == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           directory: ./.reports/
           fail_ci_if_error: true
-          files: integration.xml
+          file: integration.xml
           flags: integration
           verbose: true
 
 # Uncomment when scenario test cases are working again
 #      - name: Upload Scenario Test Coverage
+#        if: matrix.os-version == 'ubuntu-latest'
 #        uses: codecov/codecov-action@v3
 #        with:
 #          directory: ./.reports/
 #          fail_ci_if_error: true
-#          files: scenarios.xml
+#          file: scenarios.xml
 #          flags: scenarios
 #          verbose: true
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       LANG: en_US.UTF-8
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9] #, '3.10'] <-- auto fails due to lack of 3.10 test in tox.ini
+        python-version: [3.5, 3.6, 3.7, 3.8] #, 3.9, '3.10'] <-- auto fails due to lack of 3.9 & 3.10 env in tox.ini
         os-version: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       LANG: en_US.UTF-8
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8] #, 3.9, '3.10'] <-- auto fails due to lack of 3.9 & 3.10 env in tox.ini
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9] #, '3.10'] <-- auto fails due to lack of 3.9 & 3.10 env in tox.ini
         os-version: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -49,13 +49,31 @@ jobs:
         run: |
           tox
 
-      - name: Upload Test Coverage
+      - name: Upload Unit Test Coverage
         uses: codecov/codecov-action@v3
         with:
           directory: ./.reports/
           fail_ci_if_error: true
-          files: unit.xml, integration.xml, scenarios.xml
-          flags: unit, integration, scenarios
+          files: unit.xml
+          flags: unit
+          verbose: true
+
+      - name: Upload Integration Test Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./.reports/
+          fail_ci_if_error: true
+          files: integration.xml
+          flags: integration
+          verbose: true
+
+      - name: Upload Scenario Test Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./.reports/
+          fail_ci_if_error: true
+          files: scenarios.xml
+          flags: scenarios
           verbose: true
 
   gh-pages:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -41,13 +41,31 @@ jobs:
 
       - name: Install dependencies (Common)
         run: |
-          # Setup tox & Codecov uploader
+          # Setup tox & code coverage
           pip install --upgrade pip
           pip install tox tox-gh-actions pytest pytest-cov
 
       - name: Run Tests
         run: |
           tox
+
+      - name: Upload Unit Test Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./.reports/
+          fail_ci_if_error: true
+          files: unit.xml
+          flags: unit
+          verbose: true
+
+      - name: Upload Integration Test Coverage
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./.reports/
+          fail_ci_if_error: true
+          files: integration.xml
+          flags: integration
+          verbose: true
 
 
   gh-pages:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       LANG: en_US.UTF-8
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9] #, '3.10'] <-- auto fails due to lack of 3.10 test in tox.ini
         os-version: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -49,24 +49,14 @@ jobs:
         run: |
           tox
 
-      - name: Upload Unit Test Coverage
+      - name: Upload Test Coverage
         uses: codecov/codecov-action@v3
         with:
           directory: ./.reports/
           fail_ci_if_error: true
-          files: unit.xml
-          flags: unit
+          files: unit.xml, integration.xml, scenarios.xml
+          flags: unit, integration, scenarios
           verbose: true
-
-      - name: Upload Integration Test Coverage
-        uses: codecov/codecov-action@v3
-        with:
-          directory: ./.reports/
-          fail_ci_if_error: true
-          files: integration.xml
-          flags: integration
-          verbose: true
-
 
   gh-pages:
     name: "Build Documentation"

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@
 # configuration options.
 
 [tox]
-envlist = py37-{unit,integration}
-#envlist = py{35,36,37,38,39}-tests
+#envlist = py37-{unit,integration}
+envlist = py{35,36,37,38,39}-{unit,integration}
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -19,10 +19,10 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 # Required by tox-gh-actions GH action.  Maps GH Python runtime to tox envlist.
 [gh-actions]
 python =
-#    3.5: py35
-#    3.6: py36
+    3.5: py35
+    3.6: py36
     3.7: py37
-#    3.8: py38
+    3.8: py38
 #    3.9: py39
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -83,6 +83,7 @@ commands =
     codecov: codecov -e TOXENV -F unit
 
 [testenv:integration]
+commands =
 #    flake8: flake8 {posargs:src/sasctl}
     tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-append --cov-report=  tests/integration}
     codecov: codecov -e TOXENV -F integration

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 
 [tox]
 #envlist = clean, py37-tests-{unit,integration}, report
-envlist = py{35,36,37,38,39}-tests-{clean,unit,integration}
+envlist = py{35,36,37,38,39}-tests-{clean,unit,integration,scenario}
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -79,7 +79,7 @@ commands =
 #    flake8: flake8 {posargs:src/sasctl}
     unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/unit.xml --cov-append tests/unit/}
     integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/integration.xml --cov-append tests/integration/}
-#    codecov: codecov -e TOXENV -c {True,False} -F {unit,integration}
+    scenarios: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/scenarios.xml --cov-append tests/scenarios/}
     clean: coverage erase
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 
 [tox]
 #envlist = clean, py37-tests-{unit,integration}, report
-envlist = clean, py{35,36,37,38,39}-tests
+envlist = py{35,36,37,38,39}-tests-{clean,unit,integration}
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -34,7 +34,7 @@ skip_install =
 basepython =
     py35: python3.5
     py36: python3.6
-    py37, clean: python3.7
+    py37: python3.7
     py38: python3.8
     py39: python3.9
 
@@ -58,7 +58,6 @@ deps =
     tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
     tests: xgboost == 0.82
 #    {unit,integration}: lightgbm ; platform_system != "Darwin"  # lightgbm seems to have build issues on MacOS
-    report: coverage
     doc: sphinx == 1.8
 # doc skips install, so explicitly add minimum packages
     doc: pyyaml
@@ -70,11 +69,11 @@ setenv =
     tests: REQUESTS_CA_BUNDLE=
 
 passenv =
-    clean,report: TOXENV
-    clean,report: CI
-    clean,report: TRAVIS
-    clean,report: TRAVIS_*
-    clean,report: CODEVOC_*
+    tests: TOXENV
+    tests: CI
+    tests: TRAVIS
+    tests: TRAVIS_*
+    tests: CODEVOC_*
 
 commands =
 #    flake8: flake8 {posargs:src/sasctl}

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,9 @@
 # configuration options.
 
 [tox]
-#envlist = clean, py37-tests-{unit,integration}, report
-envlist = py{35,36,37,38,39}-tests-{clean,unit,integration,scenario}
+envlist = py{35,36,37,38}-tests-{clean,unit,integration}
+# py{39,310} don't work with swat|pandas version requirements
+# py{}-tests-{scenarios} don't work since tests are being skipped automatically
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -23,7 +24,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39
+#    3.9: py39
 
 [testenv]
 skip_install =
@@ -36,7 +37,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
-    py39: python3.9
+#    py39: python3.9
 
 deps =
     clean: coverage
@@ -57,7 +58,7 @@ deps =
     tests: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
     tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
     tests: xgboost == 0.82
-#    {unit,integration}: lightgbm ; platform_system != "Darwin"  # lightgbm seems to have build issues on MacOS
+#    tests: lightgbm ; platform_system != "Darwin"  # lightgbm seems to have build issues on MacOS
     doc: sphinx == 1.8
 # doc skips install, so explicitly add minimum packages
     doc: pyyaml

--- a/tox.ini
+++ b/tox.ini
@@ -77,13 +77,13 @@ passenv =
     codecov: CODEVOC_*
 
 commands =
-    clean: coverage erase
+#    clean: coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
     unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit/}
 #    unit: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\unit\}
     integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/integration/}
 #    integration: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\integration\}
-    codecov: codecov -e TOXENV
+    codecov: codecov -e TOXENV -c {True,False} -F {unit,integration}
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands =
 #    flake8: flake8 {posargs:src/sasctl}
     unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit/}
 #    unit: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\unit\}
-#    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/integration/}
+    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/integration/}
 #    integration: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\integration\}
     codecov: codecov -e TOXENV
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-#   3.9: py39
+    3.9: py39
 
 [testenv]
 skip_install =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@
 # configuration options.
 
 [tox]
-envlist = py{35,36,37,38,39}-tests
+envlist = py37-{unit,integration}
+#envlist = py{35,36,37,38,39}-tests
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -18,11 +19,11 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 # Required by tox-gh-actions GH action.  Maps GH Python runtime to tox envlist.
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
+#    3.5: py35
+#    3.6: py36
     3.7: py37
-    3.8: py38
-    3.9: py39
+#    3.8: py38
+#    3.9: py39
 
 [testenv]
 skip_install =
@@ -46,27 +47,27 @@ deps =
     flake8: flake8-import-order
     flake8: flake8-logging-format
     flake8: pydocstyle < 4.0.0      # Issue with flake8-docstings  https://github.com/PyCQA/pydocstyle/issues/375
-    tests: pytest >= 4.4.1
-    tests: pytest-cov
-    tests: betamax >= 0.8.1
-    tests: betamax_serializers >= 0.2.0
-    tests: mock; python_version < '3.3'
-    tests: sklearn
-    tests: pandas<1.0.0
-    tests: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
-    tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
-    tests: xgboost == 0.82
-#    tests: lightgbm ; platform_system != "Darwin"  # lightgmb seems to have build issues on MacOS
+    {unit,integration}: pytest >= 4.4.1
+    {unit,integration}: pytest-cov
+    {unit,integration}: betamax >= 0.8.1
+    {unit,integration}: betamax_serializers >= 0.2.0
+    {unit,integration}: mock; python_version < '3.3'
+    {unit,integration}: sklearn
+    {unit,integration}: pandas<1.0.0
+    {unit,integration}: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
+    {unit,integration}: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
+    {unit,integration}: xgboost == 0.82
+#    {unit,integration}: lightgbm ; platform_system != "Darwin"  # lightgbm seems to have build issues on MacOS
     codecov: codecov >= 1.4.0
     doc: sphinx == 1.8
 # doc skips install, so explicitly add minimum packages
     doc: pyyaml
 
 setenv =
-    tests: SASCTL_USER_NAME=dummy
-    tests: SASCTL_PASSWORD=dummy
-    tests: SASCTL_TEST_SERVERS=example.com
-    tests: REQUESTS_CA_BUNDLE=
+    {unit,integration}: SASCTL_USER_NAME=dummy
+    {unit,integration}: SASCTL_PASSWORD=dummy
+    {unit,integration}: SASCTL_TEST_SERVERS=example.com
+    {unit,integration}: REQUESTS_CA_BUNDLE=
 
 passenv =
     codecov: TOXENV
@@ -75,18 +76,14 @@ passenv =
     codecov: TRAVIS_*
     codecov: CODEVOC_*
 
-[testenv:unit]
 commands =
-    clean:  coverage erase
+    clean: coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
-    tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit}
-    codecov: codecov -e TOXENV -F unit
-
-[testenv:integration]
-commands =
-#    flake8: flake8 {posargs:src/sasctl}
-    tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-append --cov-report=  tests/integration}
-    codecov: codecov -e TOXENV -F integration
+    unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit/}
+#    unit: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\unit\}
+#    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/integration/}
+#    integration: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\integration\}
+    codecov: codecov -e TOXENV
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@
 # configuration options.
 
 [tox]
-envlist = py37-tests
-#py{35,36,37,38,39}-tests
+envlist = py{35,36,37,38,39}-tests
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -19,24 +18,24 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 # Required by tox-gh-actions GH action.  Maps GH Python runtime to tox envlist.
 [gh-actions]
 python =
-#    3.5: py35
-#    3.6: py36
+    3.5: py35
+    3.6: py36
     3.7: py37
-#    3.8: py38
-#    3.9: py39
+    3.8: py38
+    3.9: py39
 
-[testenv:unit]
+[testenv]
 skip_install =
     clean: true
     flake8: true
     doc: true
 
 basepython =
-#    py35: python3.5
-#    py36: python3.6
+    py35: python3.5
+    py36: python3.6
     py37: python3.7
-#    py38: python3.8
-#    py39: python3.9
+    py38: python3.8
+    py39: python3.9
 
 deps =
     clean: coverage
@@ -76,66 +75,14 @@ passenv =
     codecov: TRAVIS_*
     codecov: CODEVOC_*
 
+[testenv:unit]
 commands =
     clean:  coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
     tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit}
     codecov: codecov -e TOXENV -F unit
-#    doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 
 [testenv:integration]
-skip_install =
-    clean: true
-    flake8: true
-    doc: true
-
-basepython =
-#    py35: python3.5
-#    py36: python3.6
-    py37: python3.7
-#    py38: python3.8
-#    py39: python3.9
-
-deps =
-    clean: coverage
-    flake8: flake8 == 3.7.7
-    flake8: flake8-bugbear
-    flake8: flake8-docstrings
-    flake8: flake8-rst-docstrings
-    flake8: flake8-import-order
-    flake8: flake8-logging-format
-    flake8: pydocstyle < 4.0.0      # Issue with flake8-docstings  https://github.com/PyCQA/pydocstyle/issues/375
-    tests: pytest >= 4.4.1
-    tests: pytest-cov
-    tests: betamax >= 0.8.1
-    tests: betamax_serializers >= 0.2.0
-    tests: mock; python_version < '3.3'
-    tests: sklearn
-    tests: pandas<1.0.0
-    tests: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
-    tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
-    tests: xgboost == 0.82
-#    tests: lightgbm ; platform_system != "Darwin"  # lightgmb seems to have build issues on MacOS
-    codecov: codecov >= 1.4.0
-    doc: sphinx == 1.8
-# doc skips install, so explicitly add minimum packages
-    doc: pyyaml
-
-setenv =
-    tests: SASCTL_USER_NAME=dummy
-    tests: SASCTL_PASSWORD=dummy
-    tests: SASCTL_TEST_SERVERS=example.com
-    tests: REQUESTS_CA_BUNDLE=
-
-passenv =
-    codecov: TOXENV
-    codecov: CI
-    codecov: TRAVIS
-    codecov: TRAVIS_*
-    codecov: CODEVOC_*
-
-commands =
-#    clean:  coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
     tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-append --cov-report=  tests/integration}
     codecov: codecov -e TOXENV -F integration

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@
 # configuration options.
 
 [tox]
-envlist = py{34,35,36,37,38,39}-tests
+envlist = py37-tests
+#py{35,36,37,38,39}-tests
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -18,26 +19,24 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 # Required by tox-gh-actions GH action.  Maps GH Python runtime to tox envlist.
 [gh-actions]
 python =
-    3.5: py35
-    3.6: py36
+#    3.5: py35
+#    3.6: py36
     3.7: py37
-    3.8: py38
-    3.9: py39
+#    3.8: py38
+#    3.9: py39
 
-[testenv:unittests]
+[testenv:unit]
 skip_install =
     clean: true
     flake8: true
     doc: true
 
 basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
+#    py35: python3.5
+#    py36: python3.6
     py37: python3.7
-    py38: python3.8
-;    py39: python3.9
+#    py38: python3.8
+#    py39: python3.9
 
 deps =
     clean: coverage
@@ -80,10 +79,67 @@ passenv =
 commands =
     clean:  coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
-    tests:  {posargs:py.test tests/unit/ --cov={envsitepackagesdir}/sasctl --cov-append --cov-report= }
-    codecov: codecov -e TOXENV
-    doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
+    tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit}
+    codecov: codecov -e TOXENV -F unit
+#    doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 
+[testenv:integration]
+skip_install =
+    clean: true
+    flake8: true
+    doc: true
+
+basepython =
+#    py35: python3.5
+#    py36: python3.6
+    py37: python3.7
+#    py38: python3.8
+#    py39: python3.9
+
+deps =
+    clean: coverage
+    flake8: flake8 == 3.7.7
+    flake8: flake8-bugbear
+    flake8: flake8-docstrings
+    flake8: flake8-rst-docstrings
+    flake8: flake8-import-order
+    flake8: flake8-logging-format
+    flake8: pydocstyle < 4.0.0      # Issue with flake8-docstings  https://github.com/PyCQA/pydocstyle/issues/375
+    tests: pytest >= 4.4.1
+    tests: pytest-cov
+    tests: betamax >= 0.8.1
+    tests: betamax_serializers >= 0.2.0
+    tests: mock; python_version < '3.3'
+    tests: sklearn
+    tests: pandas<1.0.0
+    tests: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
+    tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
+    tests: xgboost == 0.82
+#    tests: lightgbm ; platform_system != "Darwin"  # lightgmb seems to have build issues on MacOS
+    codecov: codecov >= 1.4.0
+    doc: sphinx == 1.8
+# doc skips install, so explicitly add minimum packages
+    doc: pyyaml
+
+setenv =
+    tests: SASCTL_USER_NAME=dummy
+    tests: SASCTL_PASSWORD=dummy
+    tests: SASCTL_TEST_SERVERS=example.com
+    tests: REQUESTS_CA_BUNDLE=
+
+passenv =
+    codecov: TOXENV
+    codecov: CI
+    codecov: TRAVIS
+    codecov: TRAVIS_*
+    codecov: CODEVOC_*
+
+commands =
+#    clean:  coverage erase
+#    flake8: flake8 {posargs:src/sasctl}
+    tests: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-append --cov-report=  tests/integration}
+    codecov: codecov -e TOXENV -F integration
+    doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 
 [flake8]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@
 # configuration options.
 
 [tox]
-envlist = clean, py37-tests-{unit,integration}
-#envlist = py{35,36,37,38,39}-tests-{unit,integration}
+#envlist = clean, py37-tests-{unit,integration}, report
+envlist = clean, py{35,36,37,38,39}-tests
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -34,7 +34,7 @@ skip_install =
 basepython =
     py35: python3.5
     py36: python3.6
-    py37: python3.7
+    py37, clean: python3.7
     py38: python3.8
     py39: python3.9
 
@@ -70,27 +70,19 @@ setenv =
     tests: REQUESTS_CA_BUNDLE=
 
 passenv =
-    clean,tests: TOXENV
-    clean,tests: CI
-    clean,tests: TRAVIS
-    clean,tests: TRAVIS_*
-    clean,tests: CODEVOC_*
+    clean,report: TOXENV
+    clean,report: CI
+    clean,report: TRAVIS
+    clean,report: TRAVIS_*
+    clean,report: CODEVOC_*
 
 commands =
 #    flake8: flake8 {posargs:src/sasctl}
-    unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=term-missing --cov-append tests/unit/} \
-    unit: coverage -c -F unit
-#    unit: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\unit\}
-    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=term-missing --cov-append tests/integration/} \
-    integration: coverage -c -F integration
-#    integration: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\integration\}
+    unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/unit.xml --cov-append tests/unit/}
+    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/integration.xml --cov-append tests/integration/}
 #    codecov: codecov -e TOXENV -c {True,False} -F {unit,integration}
+    clean: coverage erase
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
-
-[testenv:clean]
-deps = coverage
-skip_install = true
-commands = coverage erase
 
 [flake8]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ commands =
 #    flake8: flake8 {posargs:src/sasctl}
     unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/unit.xml --cov-append tests/unit/}
     integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/integration.xml --cov-append tests/integration/}
-    scenarios: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/scenarios.xml --cov-append tests/scenarios/}
+#    scenarios: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=xml:./.reports/scenarios.xml --cov-append tests/scenarios/}
     clean: coverage erase
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@
 # configuration options.
 
 [tox]
-#envlist = py37-{unit,integration}
-envlist = py{35,36,37,38,39}-{unit,integration}
+envlist = clean, py37-tests-{unit,integration}
+#envlist = py{35,36,37,38,39}-tests-{unit,integration}
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -23,12 +23,12 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-#    3.9: py39
+#   3.9: py39
 
 [testenv]
 skip_install =
     clean: true
-    flake8: true
+#    flake8: true
     doc: true
 
 basepython =
@@ -40,51 +40,57 @@ basepython =
 
 deps =
     clean: coverage
-    flake8: flake8 == 3.7.7
-    flake8: flake8-bugbear
-    flake8: flake8-docstrings
-    flake8: flake8-rst-docstrings
-    flake8: flake8-import-order
-    flake8: flake8-logging-format
-    flake8: pydocstyle < 4.0.0      # Issue with flake8-docstings  https://github.com/PyCQA/pydocstyle/issues/375
-    {unit,integration}: pytest >= 4.4.1
-    {unit,integration}: pytest-cov
-    {unit,integration}: betamax >= 0.8.1
-    {unit,integration}: betamax_serializers >= 0.2.0
-    {unit,integration}: mock; python_version < '3.3'
-    {unit,integration}: sklearn
-    {unit,integration}: pandas<1.0.0
-    {unit,integration}: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
-    {unit,integration}: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
-    {unit,integration}: xgboost == 0.82
+#    flake8: flake8 == 3.7.7
+#    flake8: flake8-bugbear
+#    flake8: flake8-docstrings
+#    flake8: flake8-rst-docstrings
+#    flake8: flake8-import-order
+#    flake8: flake8-logging-format
+#    flake8: pydocstyle < 4.0.0      # Issue with flake8-docstings  https://github.com/PyCQA/pydocstyle/issues/375
+    tests: pytest >= 4.4.1
+    tests: pytest-cov
+    tests: betamax >= 0.8.1
+    tests: betamax_serializers >= 0.2.0
+    tests: mock; python_version < '3.3'
+    tests: sklearn
+    tests: pandas<1.0.0
+    tests: swat < 1.8.0         # v1.8 changed reflection on initial connect.  Need to re-record all cassettes before enabling.
+    tests: kerberos ; platform_system != "Windows" and platform_system != "Darwin"
+    tests: xgboost == 0.82
 #    {unit,integration}: lightgbm ; platform_system != "Darwin"  # lightgbm seems to have build issues on MacOS
-    codecov: codecov >= 1.4.0
+    report: coverage
     doc: sphinx == 1.8
 # doc skips install, so explicitly add minimum packages
     doc: pyyaml
 
 setenv =
-    {unit,integration}: SASCTL_USER_NAME=dummy
-    {unit,integration}: SASCTL_PASSWORD=dummy
-    {unit,integration}: SASCTL_TEST_SERVERS=example.com
-    {unit,integration}: REQUESTS_CA_BUNDLE=
+    tests: SASCTL_USER_NAME=dummy
+    tests: SASCTL_PASSWORD=dummy
+    tests: SASCTL_TEST_SERVERS=example.com
+    tests: REQUESTS_CA_BUNDLE=
 
 passenv =
-    codecov: TOXENV
-    codecov: CI
-    codecov: TRAVIS
-    codecov: TRAVIS_*
-    codecov: CODEVOC_*
+    clean,tests: TOXENV
+    clean,tests: CI
+    clean,tests: TRAVIS
+    clean,tests: TRAVIS_*
+    clean,tests: CODEVOC_*
 
 commands =
-#    clean: coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
-    unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/unit/}
+    unit: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=term-missing --cov-append tests/unit/} \
+    unit: coverage -c -F unit
 #    unit: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\unit\}
-    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=  tests/integration/}
+    integration: {posargs:pytest --cov={envsitepackagesdir}/sasctl --cov-report=term-missing --cov-append tests/integration/} \
+    integration: coverage -c -F integration
 #    integration: {posargs:pytest --cov=C:\ProgramData\Anaconda3\envs\py37\Lib\site-packages\sasctl --disable-warnings tests\integration\}
-    codecov: codecov -e TOXENV -c {True,False} -F {unit,integration}
+#    codecov: codecov -e TOXENV -c {True,False} -F {unit,integration}
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
 
 [flake8]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,8 @@
 # See also https://tox.readthedocs.io/en/latest/config.html for more
 # configuration options.
 
-
-
 [tox]
-envlist = py{27,34,35,36,37,38,39}-tests
+envlist = py{34,35,36,37,38,39}-tests
 
 # Allow execution even if all Python versions are not present
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
@@ -26,7 +24,7 @@ python =
     3.8: py38
     3.9: py39
 
-[testenv]
+[testenv:unittests]
 skip_install =
     clean: true
     flake8: true
@@ -82,7 +80,7 @@ passenv =
 commands =
     clean:  coverage erase
 #    flake8: flake8 {posargs:src/sasctl}
-    tests:  {posargs:py.test --cov={envsitepackagesdir}/sasctl --cov-report= }
+    tests:  {posargs:py.test tests/unit/ --cov={envsitepackagesdir}/sasctl --cov-append --cov-report= }
     codecov: codecov -e TOXENV
     doc:    sphinx-build -Ean -b html -j auto ./doc ./doc/_build/html
 


### PR DESCRIPTION
Merge new code coverage flags into master branch. All code coverage flag and upload calls are handled by the git action instead of inside the tox.ini file. 

This now separates out the coverage via unit, integration, and scenario (once it starts working again) tests, but still collates to a merged total value.