### PR TITLE
Publish model versions - added another unit test

### DIFF
--- a/src/sasctl/_services/model_management.py
+++ b/src/sasctl/_services/model_management.py
@@ -44,8 +44,8 @@ class ModelManagement(Service):
             The name or id of the model, or a dictionary representation of the model.
         destination : str
             Name of destination to publish the model to.
-        model_version_id : str or dict, optional
-            Provide the id, name, or dictionary representation of the version to publish. Defaults to 'latest'.
+        model_version : str or dict, optional
+            Provide the version id, name, or dict to publish. Defaults to 'latest'.
         name : str, optional
             Provide a custom name for the published model. Defaults to None.
         force : bool, optional
@@ -164,7 +164,7 @@ class ModelManagement(Service):
             multiple models, input a list of model names, or a list of dictionaries. If no models are specified, all
             models in the project specified will be used. Defaults to None.
         modelVersions: str, list, optional
-            The name of the model version(s). Defaults to None, where all models are latest.
+            The name of the model version(s). Defaults to None, i.e. all models are latest.
         library_name : str
             The library containing the input data, default is 'Public'.
         name : str, optional
@@ -322,7 +322,7 @@ class ModelManagement(Service):
     @classmethod
     def check_model_versions(cls, models, modelVersions):
         """
-        Checking if the model version(s) are valid. Appending them to the model_id accordingly.
+        Checking if the model version(s) are valid and append to model id accordingly.
 
         Parameters
         ----------
@@ -337,38 +337,38 @@ class ModelManagement(Service):
         """
         if not modelVersions:
             return [model.id for model in models]
-        else:
-            updated_models = []
-            if not isinstance(modelVersions, list):
-                modelVersions = [modelVersions]
 
-            if len(models) < len(modelVersions):
-                raise ValueError(
-                    "There are too many versions for the amount of models specified."
-                )
+        updated_models = []
+        if not isinstance(modelVersions, list):
+            modelVersions = [modelVersions]
 
-            modelVersions = modelVersions + [""] * (len(models) - len(modelVersions))
-            for model, modelVersionName in zip(models, modelVersions):
+        if len(models) < len(modelVersions):
+            raise ValueError(
+                "There are too many versions for the amount of models specified."
+            )
 
-                if (
-                    isinstance(modelVersionName, dict)
-                    and "modelVersionName" in modelVersionName
-                ):
+        modelVersions = modelVersions + [""] * (len(models) - len(modelVersions))
+        for model, modelVersionName in zip(models, modelVersions):
 
-                    modelVersionName = modelVersionName["modelVersionName"]
-                elif (
-                    isinstance(modelVersionName, dict)
-                    and "modelVersionName" not in modelVersionName
-                ):
+            if (
+                isinstance(modelVersionName, dict)
+                and "modelVersionName" in modelVersionName
+            ):
 
-                    raise ValueError("Model version is not recognized.")
+                modelVersionName = modelVersionName["modelVersionName"]
+            elif (
+                isinstance(modelVersionName, dict)
+                and "modelVersionName" not in modelVersionName
+            ):
 
-                if modelVersionName != "":
-                    updated_models.append(model.id + ":" + modelVersionName)
-                else:
-                    updated_models.append(model.id)
+                raise ValueError("Model version is not recognized.")
 
-            return updated_models
+            if modelVersionName != "":
+                updated_models.append(model.id + ":" + modelVersionName)
+            else:
+                updated_models.append(model.id)
+
+        return updated_models
 
     @classmethod
     def execute_performance_definition(cls, definition):

--- a/src/sasctl/_services/model_management.py
+++ b/src/sasctl/_services/model_management.py
@@ -278,7 +278,6 @@ class ModelManagement(Service):
 
             modelVersions = modelVersions + [""] * (len(models) - len(modelVersions))
             for model, modelVersionName in zip(models, modelVersions):
-                print(model.name)
                 if (
                     isinstance(modelVersionName, dict)
                     and "modelVersionName" in modelVersionName

--- a/src/sasctl/_services/model_management.py
+++ b/src/sasctl/_services/model_management.py
@@ -164,7 +164,7 @@ class ModelManagement(Service):
             multiple models, input a list of model names, or a list of dictionaries. If no models are specified, all
             models in the project specified will be used. Defaults to None.
         modelVersions: str, list, optional
-            The name of the model version(s). Defaults to None, i.e. all models are latest.
+            The name of the model version(s). Defaults to None, so all models are latest.
         library_name : str
             The library containing the input data, default is 'Public'.
         name : str, optional

--- a/src/sasctl/_services/model_publish.py
+++ b/src/sasctl/_services/model_publish.py
@@ -10,6 +10,7 @@ import re
 
 from .model_repository import ModelRepository
 from .service import Service
+from ..utils.decorators import deprecated
 
 
 class ModelPublish(Service):
@@ -90,7 +91,7 @@ class ModelPublish(Service):
 
         return cls.delete("/destinations/{name}".format(name=item))
 
-    @classmethod
+    @deprecated("Use publish_model in model_management.py instead.", "1.11.5")
     def publish_model(cls, model, destination, name=None, code=None, notes=None):
         """Publish a model to an existing publishing destination.
 

--- a/src/sasctl/_services/score_definitions.py
+++ b/src/sasctl/_services/score_definitions.py
@@ -188,7 +188,6 @@ class ScoreDefinitions(Service):
             ):
                 raise ValueError("Model version cannot be found.")
             elif isinstance(model_version, str) and cls.is_uuid(model_version):
-                print("hello")
                 model_version = cls._model_repository.get_model_or_version(
                     model_id, model_version
                 )["modelVersionName"]

--- a/src/sasctl/_services/score_definitions.py
+++ b/src/sasctl/_services/score_definitions.py
@@ -133,7 +133,15 @@ class ScoreDefinitions(Service):
 
             if isinstance(model_version, dict) and "modelVersionName" in model_version:
                 model_version = model_version["modelVersionName"]
+            elif (
+                isinstance(model_version, dict)
+                and "modelVersionName" not in model_version
+            ):
+                raise ValueError(
+                    "Model version cannot be found. Please check the inputted model version."
+                )
             elif isinstance(model_version, str) and cls.is_uuid(model_version):
+                print("hello")
                 model_version = cls._model_repository.get_model_or_version(
                     model_id, model_version
                 )["modelVersionName"]

--- a/src/sasctl/_services/score_definitions.py
+++ b/src/sasctl/_services/score_definitions.py
@@ -116,7 +116,7 @@ class ScoreDefinitions(Service):
         table = cls._cas_management.get_table(table_name, library_name, server_name)
         if not table and not table_file:
             raise HTTPError(
-                "This table may not exist in CAS. Please include the `table_file` argument."
+                "This table may not exist in CAS. Include the `table_file` argument."
             )
         elif not table and table_file:
             cls._cas_management.upload_file(

--- a/tests/unit/test_score_definitions.py
+++ b/tests/unit/test_score_definitions.py
@@ -63,89 +63,166 @@ def test_create_score_definition():
                 "sasctl._services.cas_management.CASManagement.upload_file"
             ) as upload_file:
                 with mock.patch(
-                    "sasctl._services.score_definitions.ScoreDefinitions.post"
-                ) as post:
-                    # Invalid model id test case
-                    get_model.return_value = None
-                    with pytest.raises(HTTPError):
-                        sd.create_score_definition(
-                            score_def_name="test_create_sd",
-                            model="12345",
-                            table_name="test_table",
-                        )
-                    # Valid model id but invalid table name with no table_file argument test case
-                    get_model_mock = {
-                        "id": "12345",
-                        "projectId": "54321",
-                        "projectVersionId": "67890",
-                        "name": "test_model",
-                    }
-                    get_model.return_value = get_model_mock
-                    get_table.return_value = None
-                    with pytest.raises(HTTPError):
-                        sd.create_score_definition(
-                            score_def_name="test_create_sd",
-                            model="12345",
-                            table_name="test_table",
-                        )
+                    "sasctl._services.model_repository.ModelRepository.get_model_or_version"
+                ) as get_model_or_version:
+                    with mock.patch(
+                        "sasctl._services.score_definitions.ScoreDefinitions.is_uuid"
+                    ) as is_uuid:
+                        with mock.patch(
+                            "sasctl._services.score_definitions.ScoreDefinitions.post"
+                        ) as post:
 
-                    # Invalid table name with a table_file argument that doesn't work test case
-                    get_table.return_value = None
-                    upload_file.return_value = None
-                    get_table.return_value = None
-                    with pytest.raises(HTTPError):
-                        sd.create_score_definition(
-                            score_def_name="test_create_sd",
-                            model="12345",
-                            table_name="test_table",
-                            table_file="test_path",
-                        )
+                            # Invalid model id test case
+                            get_model.return_value = None
+                            with pytest.raises(HTTPError):
+                                sd.create_score_definition(
+                                    score_def_name="test_create_sd",
+                                    model="12345",
+                                    table_name="test_table",
+                                )
+                            # Valid model id but invalid table name with no table_file argument test case
+                            get_model_mock = {
+                                "id": "12345",
+                                "projectId": "54321",
+                                "projectVersionId": "67890",
+                                "name": "test_model",
+                            }
+                            get_model.return_value = get_model_mock
+                            get_table.return_value = None
+                            with pytest.raises(HTTPError):
+                                sd.create_score_definition(
+                                    score_def_name="test_create_sd",
+                                    model="12345",
+                                    table_name="test_table",
+                                )
 
-                    # Valid table_file argument that successfully creates a table test case
-                    get_table.return_value = None
-                    upload_file.return_value = RestObj
-                    get_table_mock = {"tableName": "test_table"}
-                    get_table.return_value = get_table_mock
-                    response = sd.create_score_definition(
-                        score_def_name="test_create_sd",
-                        model="12345",
-                        table_name="test_table",
-                        table_file="test_path",
-                    )
-                    assert response
+                            # Invalid table name with a table_file argument that doesn't work test case
+                            get_table.return_value = None
+                            upload_file.return_value = None
+                            get_table.return_value = None
+                            with pytest.raises(HTTPError):
+                                sd.create_score_definition(
+                                    score_def_name="test_create_sd",
+                                    model="12345",
+                                    table_name="test_table",
+                                    table_file="test_path",
+                                )
 
-                    # Valid table_name argument test case
-                    get_table.return_value = get_table_mock
-                    response = sd.create_score_definition(
-                        score_def_name="test_create_sd",
-                        model="12345",
-                        table_name="test_table",
-                        table_file="test_path",
-                    )
-                    assert response
+                            # Valid table_file argument that successfully creates a table test case
+                            get_table.return_value = None
+                            upload_file.return_value = RestObj
+                            get_table_mock = {"tableName": "test_table"}
+                            get_table.return_value = get_table_mock
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                                table_file="test_path",
+                            )
+                            assert response
 
-                    # Checking response with inputVariables in model elements
-                    get_model_mock = {
-                        "id": "12345",
-                        "projectId": "54321",
-                        "projectVersionId": "67890",
-                        "name": "test_model",
-                        "inputVariables": [
-                            {"name": "first"},
-                            {"name": "second"},
-                            {"name": "third"},
-                        ],
-                    }
-                    get_model.return_value = get_model_mock
-                    get_table.return_value = get_table_mock
-                    response = sd.create_score_definition(
-                        score_def_name="test_create_sd",
-                        model="12345",
-                        table_name="test_table",
-                    )
-                    assert response
-                    assert post.call_count == 3
+                            # Valid table_name argument test case
+                            get_table.return_value = get_table_mock
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                                table_file="test_path",
+                            )
+                            assert response
 
-                    data = post.call_args
-                    json_data = json.loads(data.kwargs["data"])
-                    assert json_data["mappings"] != []
+                            # Checking response with inputVariables in model elements
+                            get_model_mock = {
+                                "id": "12345",
+                                "projectId": "54321",
+                                "projectVersionId": "67890",
+                                "name": "test_model",
+                                "inputVariables": [
+                                    {"name": "first"},
+                                    {"name": "second"},
+                                    {"name": "third"},
+                                ],
+                            }
+                            get_model.return_value = get_model_mock
+                            get_table.return_value = get_table_mock
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                            )
+                            assert response
+                            assert post.call_count == 3
+
+                            data = post.call_args
+                            json_data = json.loads(data.kwargs["data"])
+                            assert json_data["mappings"] != []
+                            assert (
+                                json_data["objectDescriptor"]["name"]
+                                == "test_model (latest)"
+                            )
+                            assert (
+                                json_data["properties"]["versionedModel"]
+                                == "test_model (latest)"
+                            )
+
+                            # Model version dictionary with no model version name
+                            with pytest.raises(ValueError):
+                                response = sd.create_score_definition(
+                                    score_def_name="test_create_sd",
+                                    model="12345",
+                                    table_name="test_table",
+                                    model_version={},
+                                )
+
+                            # Model version as a model version name string, not UUID
+                            get_model.return_value = get_model_mock
+                            get_table.return_value = get_table_mock
+                            is_uuid.return_value = False
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                                model_version="1.0",
+                            )
+                            assert response
+                            assert post.call_count == 4
+
+                            data = post.call_args
+                            json_data = json.loads(data.kwargs["data"])
+                            assert (
+                                json_data["objectDescriptor"]["name"]
+                                == "test_model (1.0)"
+                            )
+                            assert (
+                                json_data["properties"]["versionedModel"]
+                                == "test_model (1.0)"
+                            )
+
+                            # Model version as a dictionary with model version name key
+                            get_version_mock = {
+                                "id": "3456",
+                                "modelVersionName": "1.0",
+                            }
+                            get_model.return_value = get_model_mock
+                            get_table.return_value = get_table_mock
+                            is_uuid.return_value = True
+                            get_model_or_version.return_value = get_version_mock
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                                model_version="3456",
+                            )
+                            assert response
+                            assert post.call_count == 5
+
+                            data = post.call_args
+                            json_data = json.loads(data.kwargs["data"])
+                            assert (
+                                json_data["objectDescriptor"]["name"]
+                                == "test_model (1.0)"
+                            )
+                            assert (
+                                json_data["properties"]["versionedModel"]
+                                == "test_model (1.0)"
+                            )

--- a/tests/unit/test_score_definitions.py
+++ b/tests/unit/test_score_definitions.py
@@ -198,6 +198,30 @@ def test_create_score_definition():
                                 == "test_model (1.0)"
                             )
 
+                            # Model version as a dict with modelVersionName key
+                            get_model.return_value = get_model_mock
+                            get_table.return_value = get_table_mock
+                            is_uuid.return_value = False
+                            response = sd.create_score_definition(
+                                score_def_name="test_create_sd",
+                                model="12345",
+                                table_name="test_table",
+                                model_version={"modelVersionName": "1.0"},
+                            )
+                            assert response
+                            assert post.call_count == 5
+
+                            data = post.call_args
+                            json_data = json.loads(data.kwargs["data"])
+                            assert (
+                                json_data["objectDescriptor"]["name"]
+                                == "test_model (1.0)"
+                            )
+                            assert (
+                                json_data["properties"]["versionedModel"]
+                                == "test_model (1.0)"
+                            )
+
                             # Model version as a dictionary with model version name key
                             get_version_mock = {
                                 "id": "3456",
@@ -214,7 +238,7 @@ def test_create_score_definition():
                                 model_version="3456",
                             )
                             assert response
-                            assert post.call_count == 5
+                            assert post.call_count == 6
 
                             data = post.call_args
                             json_data = json.loads(data.kwargs["data"])


### PR DESCRIPTION
Updated unit tests for scoreDefinitions and modelManagement. I did not add model version unit testing to publish_model due to not seeing the existing unit test. Publish_model and score_definitions have the same version logic, but I'm happy to add unit testing to all of publish_model if needed. I also broke down score definitions and create_performance_definition to make the code more readable.